### PR TITLE
Adds dynamic weighting for rules.

### DIFF
--- a/src/rita.js
+++ b/src/rita.js
@@ -2723,7 +2723,7 @@ RiString.prototype = {
 var RiGrammar = makeClass();
 
 var OR_PATT = /\s*\|\s*/, STRIP_TICKS = /`([^`]*)`/g,
-  PROB_PATT = /(.*[^\s])\s*\[([0-9.]+)\](.*)/;
+    PROB_PATT = /(.*[^\s])\s*\[(.+)\](.*)/;
 
 RiGrammar.START_RULE = "<start>";
 // Do not require a function call in the exec pattern;
@@ -2885,20 +2885,41 @@ RiGrammar.prototype = {
 
   },
 
-  doRule: function(pre) {
+  doRule: function(pre, context) {
 
     var getStochasticRule = function(temp) { // map
 
       var name, dbug = false, p = Math.random(), result, total = 0;
       if (dbug) log("getStochasticRule(" + temp + ")");
+      var rc = [];
       for (name in temp) {
-        total += parseFloat(temp[name]);
+	  let count = parseFloat(temp[name]);
+	  if (isNaN(count)) {
+	      // temp[name] is to be evaluated
+	      try {
+		  count = eval(temp[name]); // try in global context
+	      } catch (e) {
+	      };
+	      // Maybe global context didn't work?
+	      if (isNaN(count) && context) {
+		  try {
+		      count = context(temp[name]);
+		  } catch (e) { /* fall through */ }
+	      };
+	      // Maybe specific context didn't work?
+	      if (isNaN(count)) {
+		  log('Could not determine a value for rule dynamic weight: "'+temp[name]+'"');
+		  count = 0;
+	      };
+	  };
+	  rc[name] = count;
+	  total += count;
       }
 
       if (dbug) log("total=" + total + "p=" + p);
       for (name in temp) {
         if (dbug) log("  name=" + name);
-        var amt = temp[name] / total;
+        var amt = rc[name] / total;
         if (dbug) log("amt=" + amt);
         if (p < amt) {
           result = name;
@@ -2997,7 +3018,7 @@ RiGrammar.prototype = {
 
   expandFrom: function(rule, context) {
 
-    var expandRule = function(g, prod) {
+    var expandRule = function(g, prod, context) {
 
       var entry, idx, pre, expanded, post, dbug = 0;
       if (dbug) log("expandRule(" + prod + ")");
@@ -3012,7 +3033,7 @@ RiGrammar.prototype = {
 
           if (dbug) log('matched: '+name);
           pre = prod.substring(0, idx) || E;
-          expanded = g.doRule(name) || E;
+          expanded = g.doRule(name, context) || E;
           post = prod.substring(idx + name.length) || E;
 
           if (dbug) log("  pre=" + pre + "  expanded=" + expanded +
@@ -3077,7 +3098,7 @@ RiGrammar.prototype = {
 
     while (++tries < maxIterations) {
 
-      var next = expandRule(this, rule);
+      var next = expandRule(this, rule, context);
       if (next && next.length) { // matched a rule
         rule = next;
         continue;

--- a/test/RiGrammar-tests.js
+++ b/test/RiGrammar-tests.js
@@ -935,6 +935,39 @@ var runtests = function () {
     ok(res && res.match(/frog\./g));
   });
 
+  // Test a rule with a dynamic weighting
+  test("testExecDynamicWeighting", function () {
+
+    var weight = 1;
+    var noweight = 0;
+
+    var newruleg2 = {
+      '<start>': 'cat [weight] | dog [noweight]'
+    };
+
+    var rg = new RiGrammar(newruleg2);
+    rg.execDisabled = false;
+    ok(rg);
+    var res = rg.expand(function (str) { return eval(str); }); 
+    ok(res && res.indexOf("cat") != -1);
+  });
+
+  // Test a rule with a dynamic weighting, no value
+  test("testExecDynamicWeighting2", function () {
+
+    var weight = 1;
+
+    var newruleg2 = {
+      '<start>': 'cat [weight] | dog [unknownWeight]'
+    };
+
+    var rg = new RiGrammar(newruleg2);
+    rg.execDisabled = false;
+    ok(rg);
+    var res = rg.expand(function (str) { return eval(str); }); 
+    ok(res && res.indexOf("cat") != -1);
+  });
+
   test("testExecArgs", function () {
 
     var rl = RiLexicon();


### PR DESCRIPTION
PR to address second part of [dhowe/RiTa#502](https://github.com/dhowe/RiTa/issues/502) by adding dynamic weighting of rules, i.e., allowing a Javascript expression in the weight for a rule, like this:

```
 '<city>': '<city1> [x1] | <city2> [4]'
```
In this case, the rule engine tries to evaluate "x1" as an expression in the provided context. If that fails, the engine tries to evaluate the expression in the global context.  If that also fails, the engine logs a message and uses a weight of 0.  This allows dynamic weighting of rule options, and is also handy for implementing conditional rules, e.g.,

```
 '<city>': '<river-city> [isaRiver()] | <default-city>'
```
Here the function isaRiver() can return 0 when the city is not on a river, so that option will be "turned off".  Likewise if isaRiver() has not been defined.

Note that since rule weights are already delimited by brackets, there is no need for backticks around the weight expression.  The engine simply treats everything that isNaN() as an expression to be evaluated.  (It would slightly simplify the code to evaluate all weights -- because the numeric weights would evaluate to the same numeric value -- but I chose to only evaluate the non-numeric expressions.)