### PR TITLE
Adds rng parameter to RiGrammar

### DIFF
--- a/dist/rita-full.js
+++ b/dist/rita-full.js
@@ -2890,10 +2890,11 @@ RiGrammar.EXEC_PATT = /([^`]*)(`[^`]*`)(.*)/;
 
 RiGrammar.prototype = {
 
-  init: function(grammar) {
+  init: function(grammar, rng) {
 
     this._rules = {};
     this.execDisabled = false;
+    this.rng = rng ? rng : Math.random;
 
     if (grammar) {
 
@@ -3043,9 +3044,9 @@ RiGrammar.prototype = {
 
   doRule: function(pre, context) {
 
-    var getStochasticRule = function(temp) { // map
+    var getStochasticRule = function(temp, rng) { // map
 
-      var name, dbug = false, p = Math.random(), result, total = 0;
+      var name, dbug = false, p = rng(), result, total = 0;
       if (dbug) log("getStochasticRule(" + temp + ")");
       var rc = [];
       for (name in temp) {
@@ -3098,7 +3099,7 @@ RiGrammar.prototype = {
 
     if (!cnt) return null;
 
-    return (cnt == 1) ? name : getStochasticRule(rules);
+    return (cnt == 1) ? name : getStochasticRule(rules, this.rng);
   },
 
 

--- a/dist/rita-small.js
+++ b/dist/rita-small.js
@@ -2890,10 +2890,11 @@ RiGrammar.EXEC_PATT = /([^`]*)(`[^`]*`)(.*)/;
 
 RiGrammar.prototype = {
 
-  init: function(grammar) {
+  init: function(grammar, rng) {
 
     this._rules = {};
     this.execDisabled = false;
+    this.rng = rng ? rng : Math.random;
 
     if (grammar) {
 
@@ -3043,9 +3044,9 @@ RiGrammar.prototype = {
 
   doRule: function(pre, context) {
 
-    var getStochasticRule = function(temp) { // map
+    var getStochasticRule = function(temp, rng) { // map
 
-      var name, dbug = false, p = Math.random(), result, total = 0;
+      var name, dbug = false, p = rng(), result, total = 0;
       if (dbug) log("getStochasticRule(" + temp + ")");
       var rc = [];
       for (name in temp) {
@@ -3098,7 +3099,7 @@ RiGrammar.prototype = {
 
     if (!cnt) return null;
 
-    return (cnt == 1) ? name : getStochasticRule(rules);
+    return (cnt == 1) ? name : getStochasticRule(rules, this.rng);
   },
 
 

--- a/dist/rita.js
+++ b/dist/rita.js
@@ -2890,10 +2890,11 @@ RiGrammar.EXEC_PATT = /([^`]*)(`[^`]*`)(.*)/;
 
 RiGrammar.prototype = {
 
-  init: function(grammar) {
+  init: function(grammar, rng) {
 
     this._rules = {};
     this.execDisabled = false;
+    this.rng = rng ? rng : Math.random;
 
     if (grammar) {
 
@@ -3043,9 +3044,9 @@ RiGrammar.prototype = {
 
   doRule: function(pre, context) {
 
-    var getStochasticRule = function(temp) { // map
+    var getStochasticRule = function(temp, rng) { // map
 
-      var name, dbug = false, p = Math.random(), result, total = 0;
+      var name, dbug = false, p = rng(), result, total = 0;
       if (dbug) log("getStochasticRule(" + temp + ")");
       var rc = [];
       for (name in temp) {
@@ -3098,7 +3099,7 @@ RiGrammar.prototype = {
 
     if (!cnt) return null;
 
-    return (cnt == 1) ? name : getStochasticRule(rules);
+    return (cnt == 1) ? name : getStochasticRule(rules, this.rng);
   },
 
 

--- a/src/rita.js
+++ b/src/rita.js
@@ -2734,10 +2734,11 @@ RiGrammar.EXEC_PATT = /([^`]*)(`[^`]*`)(.*)/;
 
 RiGrammar.prototype = {
 
-  init: function(grammar) {
+  init: function(grammar, rng) {
 
     this._rules = {};
     this.execDisabled = false;
+    this.rng = rng ? rng : Math.random;
 
     if (grammar) {
 
@@ -2887,9 +2888,9 @@ RiGrammar.prototype = {
 
   doRule: function(pre, context) {
 
-    var getStochasticRule = function(temp) { // map
+    var getStochasticRule = function(temp, rng) { // map
 
-      var name, dbug = false, p = Math.random(), result, total = 0;
+      var name, dbug = false, p = rng(), result, total = 0;
       if (dbug) log("getStochasticRule(" + temp + ")");
       var rc = [];
       for (name in temp) {
@@ -2942,7 +2943,7 @@ RiGrammar.prototype = {
 
     if (!cnt) return null;
 
-    return (cnt == 1) ? name : getStochasticRule(rules);
+    return (cnt == 1) ? name : getStochasticRule(rules, this.rng);
   },
 
 

--- a/test/RiGrammar-tests.js
+++ b/test/RiGrammar-tests.js
@@ -968,6 +968,21 @@ var runtests = function () {
     ok(res && res.indexOf("cat") != -1);
   });
 
+  // Test specifying a random number generator
+  test("testRNG", function () {
+    var newrule = {
+      '<start>': 'cat | dog '
+    };
+    var rg = new RiGrammar(newrule, function () { return 0.25; });
+    ok(rg);
+    var res = rg.expand(function (str) { return eval(str); }); 
+    ok(res && res.indexOf("cat") != -1);
+    rg = new RiGrammar(newrule, function () { return 0.75; });
+    ok(rg);
+    res = rg.expand(function (str) { return eval(str); }); 
+    ok(res && res.indexOf("dog") != -1);
+  });
+
   test("testExecArgs", function () {
 
     var rl = RiLexicon();


### PR DESCRIPTION
This PR allows the user to specify the random number generator for RiGrammar to use as an optional second parameter when creating the RiGrammar object, e.g., 
```
var rg = new RiGrammar(newrule, myRNG);
```
If the parameter is not provided, RiGrammar will use Math.random (as it does now).

This is useful in testing (and other situations) to create reproducible results, e.g., the user can provide a [seeded random number generator](https://github.com/davidbau/seedrandom) set to a specific seed to produce the same results every time the Grammar is executed.