### PR TITLE
fix: changed rita to RiTa due to case sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ Create a new file on your desktop called 'test.html' and download the latest rit
 To install: `$ npm install rita`
 
 ```javascript
-let rita = require('rita');
+let RiTa = require('rita');
 let data = RiTa.features("The elephant took a bite!");
 console.log(data);
 ```


### PR DESCRIPTION
I have changed the variable name from `rita` to `RiTa` because it will cause an error that `RiTa is not defined` because JavaScript is case-sensitive.